### PR TITLE
Sub-menu navigation (all themes)

### DIFF
--- a/mkdocs_bootswatch/amelia/css/base.css
+++ b/mkdocs_bootswatch/amelia/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/amelia/nav-sub.html
+++ b/mkdocs_bootswatch/amelia/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/amelia/nav.html
+++ b/mkdocs_bootswatch/amelia/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/cerulean/nav-sub.html
+++ b/mkdocs_bootswatch/cerulean/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/cerulean/nav.html
+++ b/mkdocs_bootswatch/cerulean/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -115,3 +115,41 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #999999;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/cosmo/nav-sub.html
+++ b/mkdocs_bootswatch/cosmo/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/cosmo/nav.html
+++ b/mkdocs_bootswatch/cosmo/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #999999;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #fff;
+}

--- a/mkdocs_bootswatch/cyborg/nav-sub.html
+++ b/mkdocs_bootswatch/cyborg/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/cyborg/nav.html
+++ b/mkdocs_bootswatch/cyborg/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/flatly/nav-sub.html
+++ b/mkdocs_bootswatch/flatly/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/flatly/nav.html
+++ b/mkdocs_bootswatch/flatly/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/journal/nav-sub.html
+++ b/mkdocs_bootswatch/journal/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/journal/nav.html
+++ b/mkdocs_bootswatch/journal/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/readable/css/base.css
+++ b/mkdocs_bootswatch/readable/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/readable/nav-sub.html
+++ b/mkdocs_bootswatch/readable/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/readable/nav.html
+++ b/mkdocs_bootswatch/readable/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/simplex/nav-sub.html
+++ b/mkdocs_bootswatch/simplex/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/simplex/nav.html
+++ b/mkdocs_bootswatch/simplex/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #999999;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #fff;
+}

--- a/mkdocs_bootswatch/slate/nav-sub.html
+++ b/mkdocs_bootswatch/slate/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/slate/nav.html
+++ b/mkdocs_bootswatch/slate/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/spacelab/nav-sub.html
+++ b/mkdocs_bootswatch/spacelab/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/spacelab/nav.html
+++ b/mkdocs_bootswatch/spacelab/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -115,3 +115,44 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+    -webkit-border-radius: 0 4px 4px 4px;
+    -moz-border-radius: 0 4px 4px;
+    border-radius: 0 4px 4px 4px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #404040;
+}

--- a/mkdocs_bootswatch/united/nav-sub.html
+++ b/mkdocs_bootswatch/united/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/united/nav.html
+++ b/mkdocs_bootswatch/united/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -153,14 +153,3 @@ div.col-md-9 img {
 .dropdown-submenu:hover>a:after {
     border-left-color: #fff;
 }
-
-
-.dropdown-submenu.pull-left {
-    float: none;
-}
-
-/* pull sub menu left (currently not used)*/
-.dropdown-submenu.pull-left>.dropdown-menu {
-    left: -100%;
-    margin-left: 10px;
-}

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -115,3 +115,52 @@ div.col-md-9 img {
         width: 263px;
     }
 }
+
+/* display submenu relative to parent*/
+.dropdown-submenu {
+    position: relative;
+}
+
+/* sub menu stlye */
+.dropdown-submenu>.dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: 0px;
+    margin-left: -1px;
+}
+
+/* display sub menu on hover*/
+.dropdown-submenu:hover>.dropdown-menu {
+    display: block;
+}
+
+/* little arrow */
+.dropdown-submenu>a:after {
+    display: block;
+    content: " ";
+    float: right;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 5px 0 5px 5px;
+    border-left-color: #ccc;
+    margin-top: 5px;
+    margin-right: -10px;
+}
+
+/* little arrow of parent menu */
+.dropdown-submenu:hover>a:after {
+    border-left-color: #fff;
+}
+
+
+.dropdown-submenu.pull-left {
+    float: none;
+}
+
+/* pull sub menu left (currently not used)*/
+.dropdown-submenu.pull-left>.dropdown-menu {
+    left: -100%;
+    margin-left: 10px;
+}

--- a/mkdocs_bootswatch/yeti/nav-sub.html
+++ b/mkdocs_bootswatch/yeti/nav-sub.html
@@ -1,0 +1,14 @@
+{% if not nav_item.children %}
+<li {% if nav_item.active %}class="active"{% endif %}>
+    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+</li>
+{% else %}
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+    <ul class="dropdown-menu">
+        {% for nav_item in nav_item.children %}
+            {% include "nav-sub.html" %}
+        {% endfor %}
+    </ul>
+  </li>
+{% endif %}

--- a/mkdocs_bootswatch/yeti/nav.html
+++ b/mkdocs_bootswatch/yeti/nav.html
@@ -25,9 +25,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                     {% for nav_item in nav_item.children %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
+                        {% include "nav-sub.html" %}
                     {% endfor %}
                     </ul>
                 </li>


### PR DESCRIPTION
Hey, I wanted sub-menu navigation similar to what the default mkdocs theme offers in the Yeti theme, so I copied and adapted the code from [here](https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes/mkdocs).

There is some css that could be used to pull the sub-menu's to the left, but this doesn't appear to have been implemented in the mkdocs theme so I'm not sure how that would work here either.

![submenus](https://cloud.githubusercontent.com/assets/3588652/13184055/b39212ee-d731-11e5-9432-ffa1e5f1a7fd.png)

Alex


