### PR TITLE
Change the styling of inline code and allow links to colorize inline code

### DIFF
--- a/mkdocs_bootswatch/amelia/css/base.css
+++ b/mkdocs_bootswatch/amelia/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #0d747c;
+    border: solid 1px #0a565c;
+    color: #fff;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #e8d069;
+}
+
+a > code:hover, a > code:focus {
+    color: #debb27;
 }
 
 /*

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #2fa4e7;
+}
+
+a > code:hover, a > code:focus {
+    color: #157ab5;
 }
 
 /*

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #007fff;
+}
+
+a > code:hover, a > code:focus {
+    color: #0059b3;
 }
 
 /*

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -26,7 +26,21 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    background: #151515;
+    color: #888;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #2a9fd6;
 }
 
 /*

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -26,7 +26,23 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #ecf0f1;
+    border: solid 1px #ccc;
+    color: #7b8a8b;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #18bc9c;
 }
 
 /*

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #eb6864;
+}
+
+a > code:hover, a > code:focus {
+    color: #e22620;
 }
 
 /*

--- a/mkdocs_bootswatch/readable/css/base.css
+++ b/mkdocs_bootswatch/readable/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #4582ec;
+}
+
+a > code:hover, a > code:focus {
+    color: #134fb8;
 }
 
 /*

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #d9230f;
+}
+
+a > code:hover, a > code:focus {
+    color: #91170a;
 }
 
 /*

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -26,7 +26,23 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #1c1e22;
+    border: solid 1px #0c0d0e;
+    color: #c8c8c8;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #fff;
 }
 
 /*

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -26,7 +26,23 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #3399f3;
 }
 
 /*

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #dd4814;
+}
+
+a > code:hover, a > code:focus {
+    color: #97310e;
 }
 
 /*

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #008cba;
+}
+
+a > code:hover, a > code:focus {
+    color: #00526e;
 }
 
 /*


### PR DESCRIPTION
This is a port of mkdocs/mkdocs#772 to the Bootswatch themes. I can provide screenshots for all the themes if you want.

The convention I used here is to use the code block's style for the light themes, and the sidebar's style for the dark themes. There are two reasons for this: 1) it looks nicer in my opinion, and 2) it works around an issue in Firefox where we need to have the link color for inline code be the same as the "normal" link color; otherwise the underline looks weird. It's a long story.

I also chose not to give a border around the inline code in the Cyborg theme because I think it looks nicer without the border.