### PR TITLE
Support permalinks

### DIFF
--- a/mkdocs_bootswatch/amelia/css/base.css
+++ b/mkdocs_bootswatch/amelia/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #0d747c;
+    border: solid 1px #0a565c;
+    color: #fff;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #e8d069;
+}
+
+a > code:hover, a > code:focus {
+    color: #debb27;
 }
 
 /*

--- a/mkdocs_bootswatch/amelia/css/base.css
+++ b/mkdocs_bootswatch/amelia/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/amelia/css/base.css
+++ b/mkdocs_bootswatch/amelia/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/amelia/js/base.js
+++ b/mkdocs_bootswatch/amelia/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #2fa4e7;
+}
+
+a > code:hover, a > code:focus {
+    color: #157ab5;
 }
 
 /*

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/cerulean/js/base.js
+++ b/mkdocs_bootswatch/cerulean/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #007fff;
+}
+
+a > code:hover, a > code:focus {
+    color: #0059b3;
 }
 
 /*

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/cosmo/js/base.js
+++ b/mkdocs_bootswatch/cosmo/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -26,7 +26,21 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    background: #151515;
+    color: #888;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #2a9fd6;
 }
 
 /*

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+  animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -130,6 +130,15 @@ a > code {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/cyborg/js/base.js
+++ b/mkdocs_bootswatch/cyborg/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -26,7 +26,23 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #ecf0f1;
+    border: solid 1px #ccc;
+    color: #7b8a8b;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #18bc9c;
 }
 
 /*

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -132,6 +132,15 @@ a > code {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/flatly/js/base.js
+++ b/mkdocs_bootswatch/flatly/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #eb6864;
+}
+
+a > code:hover, a > code:focus {
+    color: #e22620;
 }
 
 /*

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/journal/js/base.js
+++ b/mkdocs_bootswatch/journal/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/readable/css/base.css
+++ b/mkdocs_bootswatch/readable/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #4582ec;
+}
+
+a > code:hover, a > code:focus {
+    color: #134fb8;
 }
 
 /*

--- a/mkdocs_bootswatch/readable/css/base.css
+++ b/mkdocs_bootswatch/readable/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/readable/css/base.css
+++ b/mkdocs_bootswatch/readable/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/readable/js/base.js
+++ b/mkdocs_bootswatch/readable/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #d9230f;
+}
+
+a > code:hover, a > code:focus {
+    color: #91170a;
 }
 
 /*

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/simplex/js/base.js
+++ b/mkdocs_bootswatch/simplex/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -132,6 +132,15 @@ a > code {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -26,7 +26,23 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #1c1e22;
+    border: solid 1px #0c0d0e;
+    color: #c8c8c8;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #fff;
 }
 
 /*

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/slate/js/base.js
+++ b/mkdocs_bootswatch/slate/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -132,6 +132,15 @@ a > code {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -26,7 +26,23 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #3399f3;
 }
 
 /*

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/spacelab/js/base.js
+++ b/mkdocs_bootswatch/spacelab/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #dd4814;
+}
+
+a > code:hover, a > code:focus {
+    color: #97310e;
 }
 
 /*

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/united/js/base.js
+++ b/mkdocs_bootswatch/united/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -136,6 +136,15 @@ a > code:hover, a > code:focus {
     }
 }
 
+.headerlink {
+    display: none;
+    padding-left: .5em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -26,7 +26,27 @@ div.source-links {
 }
 
 div.col-md-9 img {
-  max-width: 100%;
+    max-width: 100%;
+}
+
+code {
+    padding: 1px 3px;
+    background: #f5f5f5;
+    border: solid 1px #ccc;
+    color: #333;
+}
+
+pre code {
+    background: transparent;
+    border: none;
+}
+
+a > code {
+    color: #008cba;
+}
+
+a > code:hover, a > code:focus {
+    color: #00526e;
 }
 
 /*

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -2,11 +2,42 @@ body {
     padding-top: 70px;
 }
 
-h1[id]:before, h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before, h6[id]:before {
+/*
+ * The code below adds some padding to the top of the current anchor target so
+ * that, when navigating to it, the header isn't hidden by the navbar at the
+ * top. This is especially complicated because we want to *remove* the padding
+ * after navigation so that hovering over the header shows the permalink icon
+ * correctly. Thus, we create a CSS animation to remove the extra padding after
+ * a second. We have two animations so that navigating to an anchor within the
+ * page always restarts the animation.
+ *
+ * See <https://github.com/mkdocs/mkdocs/issues/843> for more details.
+ */
+:target::before {
     content: "";
     display: block;
     margin-top: -75px;
     height: 75px;
+    pointer-events: none;
+    animation: 0s 1s forwards collapse-anchor-padding-1;
+}
+
+body.clicky :target::before {
+    animation-name: collapse-anchor-padding-2;
+}
+
+@keyframes collapse-anchor-padding-1 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
+}
+
+@keyframes collapse-anchor-padding-2 {
+    to {
+        margin-top: 0;
+        height: 0;
+    }
 }
 
 ul.nav li.main {

--- a/mkdocs_bootswatch/yeti/js/base.js
+++ b/mkdocs_bootswatch/yeti/js/base.js
@@ -38,6 +38,11 @@ $('body').scrollspy({
     target: '.bs-sidebar',
 });
 
+/* Toggle the `clicky` class on the body when clicking links to let us
+   retrigger CSS animations. See ../css/base.css for more details. */
+$('a').click(function(e) {
+    $('body').toggleClass('clicky');
+});
 
 /* Prevent disabled links from causing a page reload */
 $("li.disabled a").click(function() {


### PR DESCRIPTION
This is based on top of #12 and both adds support for permalinks, as well as ports https://github.com/mkdocs/mkdocs/pull/846 to the Bootswatch themes.