### PR TITLE
Fix padding of code blocks so they look the same whether highlighted or not

### DIFF
--- a/mkdocs_bootswatch/amelia/css/highlight.css
+++ b/mkdocs_bootswatch/amelia/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/cerulean/css/highlight.css
+++ b/mkdocs_bootswatch/cerulean/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/cosmo/css/highlight.css
+++ b/mkdocs_bootswatch/cosmo/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/cyborg/css/highlight.css
+++ b/mkdocs_bootswatch/cyborg/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/flatly/css/highlight.css
+++ b/mkdocs_bootswatch/flatly/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/journal/css/highlight.css
+++ b/mkdocs_bootswatch/journal/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/readable/css/highlight.css
+++ b/mkdocs_bootswatch/readable/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/simplex/css/highlight.css
+++ b/mkdocs_bootswatch/simplex/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/slate/css/highlight.css
+++ b/mkdocs_bootswatch/slate/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/spacelab/css/highlight.css
+++ b/mkdocs_bootswatch/spacelab/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/united/css/highlight.css
+++ b/mkdocs_bootswatch/united/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }

--- a/mkdocs_bootswatch/yeti/css/highlight.css
+++ b/mkdocs_bootswatch/yeti/css/highlight.css
@@ -8,7 +8,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
   color: #333;
   -webkit-text-size-adjust: none;
 }


### PR DESCRIPTION
This is a port of https://github.com/mkdocs/mkdocs/pull/856 to the Bootswatch themes.