### PR TITLE
Fix padding/background color issues with hljs code blocks after #50

### DIFF
--- a/mkdocs_bootswatch/amelia/css/base.css
+++ b/mkdocs_bootswatch/amelia/css/base.css
@@ -71,8 +71,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -67,8 +67,10 @@ pre, code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/readable/css/base.css
+++ b/mkdocs_bootswatch/readable/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -71,8 +71,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -68,8 +68,10 @@ code {
 }
 
 pre code {
-    background: transparent;
     border: none;
+    /* Override styles from hljs theme */
+    background: transparent !important;
+    padding: 0 !important;
 }
 
 a code {


### PR DESCRIPTION
Prior to using hljs_style, mkdocs-bootswatch used lightly-modified versions of the themes, removing the padding and background color from the .hljs selectors. This patch restores the previous behavior by overriding those rules.

@waylan I've manually verified that all the themes look right with this patch, and it should be pixel-for-pixel identical to the old visuals now. I'm open to doing this a different way, but this patch seemed like the simplest way to do it...