### PR TITLE
Update the themes to match recent MkDocs changes

### DIFF
--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -127,7 +134,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -199,29 +208,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #2FA4E7;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -235,7 +240,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -136,7 +143,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -212,17 +221,27 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+}
+
 /* display submenu relative to parent*/
 .dropdown-submenu {
     position: relative;
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
+.dropdown-item.open {
+    color: #16181b;
+    background-color: #f8f9fa;
+}
+
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
 /* display sub menu on hover*/
@@ -231,7 +250,7 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
 }
 
 /* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -245,7 +264,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -140,7 +147,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -212,29 +221,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #2A9FD6;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -248,7 +253,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #fff;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/darkly/css/base.css
+++ b/mkdocs_bootswatch/darkly/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 4.40625rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(4.40625rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -137,7 +144,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 4.40625rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(4.40625rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -209,29 +218,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.40625rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #375a7f;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -245,7 +250,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.40625rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 4.40625rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(4.40625rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -139,7 +146,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 4.40625rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(4.40625rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -215,29 +224,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.40625rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #2C3E50;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -251,7 +256,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
-    border-left-color: #404040;
+.dropdown-submenu:hover > a::after {
+    border-left-color: #fff;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.40625rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 2rem + 27px high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(2rem + 27px + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -142,7 +149,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 2rem + 27px high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(2rem + 27px + 20px);
 }
 
 .bs-sidebar.card {
@@ -218,29 +227,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 2rem - 27px);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #151515;
+    background-color: #f8f9fa;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -254,7 +259,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 2rem - 27px);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/litera/css/base.css
+++ b/mkdocs_bootswatch/litera/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5945rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5945rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -140,7 +147,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5945rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5945rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -216,29 +225,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5945rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #16181b;
+    background-color: #f8f9fa;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -252,7 +257,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5945rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/lumen/css/base.css
+++ b/mkdocs_bootswatch/lumen/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.3125rem + 4px high, plus 20px for the margin-top of
+       the main container. */
+    scroll-padding-top: calc(3.3125rem + 4px + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -139,7 +146,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.3125rem + 4px high, plus 20px for the margin-top of
+       the main container. */
+    top: calc(3.3125rem + 4px + 20px);
 }
 
 .bs-sidebar.card {
@@ -210,29 +219,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.3125rem - 4px);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #151515;
+    background-color: #f6f6f6;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -246,7 +251,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
-    border-left-color: #404040;
+.dropdown-submenu:hover > a::after {
+    border-left-color: #151515;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.3125rem - 4px);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/lux/css/base.css
+++ b/mkdocs_bootswatch/lux/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 110px;
+    /* The nav header is 5.5784375rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(5.5784375rem + 20px);
 }
 
-body {
-    padding-top: 110px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -135,7 +142,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 110px;
+    /* The nav header is 5.5784375rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(5.5784375rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -207,26 +216,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 5.5784375rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
+.dropdown-item.open {
+    color: #0d0d0d;
+    background-color: #f8f9fa;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -240,7 +248,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
-    border-left-color: #fff;
+.dropdown-submenu:hover > a::after {
+    border-left-color: #0d0d0d;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 5.5784375rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/materia/css/base.css
+++ b/mkdocs_bootswatch/materia/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 100px;
+    /* The nav header is 5.01875rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(5.01875rem + 20px);
 }
 
-body {
-    padding-top: 100px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -126,7 +133,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 100px;
+    /* The nav header is 5.01875rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(5.01875rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -198,29 +207,27 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 5.01875rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #141414;
+    background: #f8f9fa -webkit-gradient(linear, left top, left bottom,
+                                         from(#f9fafb), to(#f8f9fa)) repeat-x;
+    background: #f8f9fa linear-gradient(180deg, #f9fafb, #f8f9fa) repeat-x;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -234,7 +241,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 5.01875rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/minty/css/base.css
+++ b/mkdocs_bootswatch/minty/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -139,7 +146,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -215,29 +224,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #F3969A;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -251,7 +256,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/pulse/css/base.css
+++ b/mkdocs_bootswatch/pulse/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 100px;
+    /* The nav header is 4.7125rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(4.7125rem + 20px);
 }
 
-body {
-    padding-top: 100px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -132,7 +139,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 100px;
+    /* The nav header is 4.7125rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(4.7125rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -204,29 +213,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.7125rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #593196;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -240,7 +245,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.7125rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/sandstone/css/base.css
+++ b/mkdocs_bootswatch/sandstone/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 2rem + 22px high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(2rem + 22px + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -127,7 +134,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 2rem + 22px high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(2rem + 22px + 20px);
 }
 
 .bs-sidebar.card {
@@ -203,29 +212,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 2rem - 22px);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #8E8C84;
+    background-color: #F8F5F0;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -239,7 +244,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 2rem - 22px);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 4.01875rem + 2px high, plus 20px for the margin-top of
+       the main container. */
+    scroll-padding-top: calc(4.01875rem + 2px + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -139,7 +146,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 4.01875rem + 2px high, plus 20px for the margin-top of
+       the main container. */
+    top: calc(4.01875rem + 2px + 20px);
 }
 
 .bs-sidebar.card {
@@ -211,29 +220,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.01875rem - 2px);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #D9230F;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -247,7 +252,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 4.01875rem - 2px);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.40625rem + 2px high, plus 20px for the margin-top of
+       the main container. */
+    scroll-padding-top: calc(3.40625rem + 2px + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -127,7 +134,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.40625rem + 2px high, plus 20px for the margin-top of
+       the main container. */
+    top: calc(3.40625rem + 2px + 20px);
 }
 
 .bs-sidebar.card {
@@ -199,29 +208,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.40625rem - 2px);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #fff;
+    background-color: #272B30;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -235,7 +240,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #fff;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.40625rem - 2px - 10px);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/solar/css/base.css
+++ b/mkdocs_bootswatch/solar/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -133,7 +140,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -209,29 +218,27 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: rgba(255,255,255,0.75);
+    background: #002B36 -webkit-gradient(linear, left top, left bottom,
+                                         from(#002b36), to(#002B36)) repeat-x;
+    background: #002B36 linear-gradient(180deg, #002b36, #002B36) repeat-x;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -245,7 +252,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem + 2px high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 2px + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -139,7 +146,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem + 2px high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 2px + 20px);
 }
 
 .bs-sidebar.card {
@@ -215,29 +224,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem - 2px);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #202020;
+    background-color: #f8f9fa;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -251,7 +256,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem - 2px);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/superhero/css/base.css
+++ b/mkdocs_bootswatch/superhero/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.018rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.018rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -134,7 +141,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.018rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.018rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -206,29 +215,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.018rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #EBEBEB;
+    background-color: rgba(255,255,255,0.075);
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -242,7 +247,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.018rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.5rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -139,7 +146,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.5rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.5rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -215,29 +224,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
-    -webkit-border-radius: 0 4px 4px 4px;
-    -moz-border-radius: 0 4px 4px;
-    border-radius: 0 4px 4px 4px;
+.dropdown-item.open {
+    color: #16181b;
+    background-color: #f8f9fa;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -251,7 +256,25 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+.dropdown-submenu:hover > a::after {
     border-left-color: #404040;
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.5rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -1,9 +1,16 @@
 html {
-    scroll-padding-top: 70px;
+    /* The nav header is 3.40625rem high, plus 20px for the margin-top of the
+       main container. */
+    scroll-padding-top: calc(3.40625rem + 20px);
 }
 
-body {
-    padding-top: 70px;
+body > .container {
+    margin-top: 20px;
+}
+
+.navbar.fixed-top {
+    position: -webkit-sticky;
+    position: sticky;
 }
 
 ul.nav .main {
@@ -136,7 +143,9 @@ footer {
 .bs-sidebar.affix {
     position: -webkit-sticky;
     position: sticky;
-    top: 80px;
+    /* The nav header is 3.40625rem high, plus 20px for the margin-top of the
+       main container. */
+    top: calc(3.40625rem + 20px);
 }
 
 .bs-sidebar.card {
@@ -208,26 +217,35 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     display:inline-block;
 }
 
-/* display submenu relative to parent*/
-.dropdown-submenu {
-    position: relative;
+@media (max-width: 991.98px) {
+    .navbar-collapse.show {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.40625rem);
+    }
 }
 
-/* sub menu stlye */
-.dropdown-submenu>.dropdown-menu {
-    top: 0;
-    left: 100%;
-    margin-top: 0px;
-    margin-left: -1px;
+.bg-primary .dropdown-item.open {
+    color: #fff;
+    background-color: #0079a1;
 }
 
-/* display sub menu on hover*/
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
+.bg-light .dropdown-item.open {
+    color: rgba(0,0,0,0.7);
+    background-color: #fbfbfb;
 }
 
-/* little arrow */
-.dropdown-submenu>a:after {
+.bg-dark .dropdown-item.open {
+    color: #fff;
+    background-color: #262626;
+}
+
+.dropdown-submenu > .dropdown-menu {
+    margin: 0 0 0 1.5rem;
+    padding: 0;
+    border-width: 0;
+}
+
+.dropdown-submenu > a::after {
     display: block;
     content: " ";
     float: right;
@@ -241,7 +259,29 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
     margin-right: -10px;
 }
 
-/* little arrow of parent menu */
-.dropdown-submenu:hover>a:after {
+dropdown-submenu:hover > a::after {
     border-left-color: #fff;
+}
+
+.bg-light dropdown-submenu:hover > a::after {
+    border-left-color: rgba(0,0,0,0.7);
+}
+
+@media (min-width: 992px) {
+    .dropdown-menu {
+        overflow-y: auto;
+        max-height: calc(100vh - 3.40625rem);
+    }
+
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu > .dropdown-menu {
+        position: fixed !important;
+        margin-top: -9px;
+        margin-left: -2px;
+        border-width: 1px;
+        padding: 0.5rem 0;
+    }
 }


### PR DESCRIPTION
This ports over the following PRs from MkDocs:
* mkdocs/mkdocs#1935
* mkdocs/mkdocs#1967
* mkdocs/mkdocs#1969
* mkdocs/mkdocs#1971

This should be pretty straightforward. The only real difference between all these versions of `base.css` is that I had to sit down and figure out exactly how tall the nav header was by default so that I could set up the offsets properly for each theme. I did that by inspecting all the CSS and just adding up the appropriate values.

I've manually tested this with every theme using every `nav_style` variant and it all looks ok as far as I can tell.