### PR TITLE
Port mkdocs/mkdocs#1970 to the Bootswatch themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ project hosted at <https://github.com/mkdocs/mkdocs>.
     * [Properly handle the scroll offset for anchors](https://github.com/mkdocs/mkdocs/pull/1935).
     * [Improve support for long dropdowns](https://github.com/mkdocs/mkdocs/pull/1967).
     * [Improve support for tall nav headers](https://github.com/mkdocs/mkdocs/pull/1969)
+    * [Use toc_tokens to generate the TOC](https://github.com/mkdocs/mkdocs/pull/1970)
 * Fix padding/background color issues with hljs code blocks.
 
 ### Version 1.0 (2018/08/03)

--- a/mkdocs_bootswatch/cerulean/css/base.css
+++ b/mkdocs_bootswatch/cerulean/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -161,7 +157,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -187,16 +183,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/cosmo/css/base.css
+++ b/mkdocs_bootswatch/cosmo/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -174,7 +170,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -200,16 +196,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/cyborg/css/base.css
+++ b/mkdocs_bootswatch/cyborg/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -174,7 +170,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -200,16 +196,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/darkly/css/base.css
+++ b/mkdocs_bootswatch/darkly/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -171,7 +167,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -197,16 +193,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/flatly/css/base.css
+++ b/mkdocs_bootswatch/flatly/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -177,7 +173,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -203,16 +199,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/journal/css/base.css
+++ b/mkdocs_bootswatch/journal/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -180,7 +176,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -206,16 +202,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/litera/css/base.css
+++ b/mkdocs_bootswatch/litera/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -178,7 +174,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -204,16 +200,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/lumen/css/base.css
+++ b/mkdocs_bootswatch/lumen/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -172,7 +168,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -198,16 +194,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/lux/css/base.css
+++ b/mkdocs_bootswatch/lux/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -169,7 +165,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -195,16 +191,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/materia/css/base.css
+++ b/mkdocs_bootswatch/materia/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -160,7 +156,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -186,16 +182,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/minty/css/base.css
+++ b/mkdocs_bootswatch/minty/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -177,7 +173,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -203,16 +199,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/pulse/css/base.css
+++ b/mkdocs_bootswatch/pulse/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -166,7 +162,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -192,16 +188,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/sandstone/css/base.css
+++ b/mkdocs_bootswatch/sandstone/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -165,7 +161,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -191,16 +187,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/simplex/css/base.css
+++ b/mkdocs_bootswatch/simplex/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -173,7 +169,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -199,16 +195,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/slate/css/base.css
+++ b/mkdocs_bootswatch/slate/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -161,7 +157,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -187,16 +183,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/solar/css/base.css
+++ b/mkdocs_bootswatch/solar/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -171,7 +167,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -197,16 +193,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/spacelab/css/base.css
+++ b/mkdocs_bootswatch/spacelab/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -177,7 +173,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -203,16 +199,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/superhero/css/base.css
+++ b/mkdocs_bootswatch/superhero/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -168,7 +164,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -194,16 +190,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/united/css/base.css
+++ b/mkdocs_bootswatch/united/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -177,7 +173,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -203,16 +199,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {

--- a/mkdocs_bootswatch/yeti/css/base.css
+++ b/mkdocs_bootswatch/yeti/css/base.css
@@ -13,10 +13,6 @@ body > .container {
     position: sticky;
 }
 
-ul.nav .main {
-    font-weight: bold;
-}
-
 .source-links {
     float: right;
 }
@@ -170,7 +166,7 @@ footer {
 }
 
 /* First level of nav */
-.bs-sidenav {
+.bs-sidebar > .navbar-collapse > .nav {
     padding-top:    10px;
     padding-bottom: 10px;
     border-radius: 5px;
@@ -196,16 +192,16 @@ footer {
     border-right: 1px solid;
 }
 
-/* Nav: second level (shown on .active) */
-.bs-sidebar .nav .nav {
-    display: none; /* Hide by default, but at >768px, show it */
-    margin-bottom: 8px;
+.bs-sidebar .nav .nav .nav {
+    margin-left: 1em;
 }
+
+.bs-sidebar .nav > li > a {
+    font-weight: bold;
+}
+
 .bs-sidebar .nav .nav > li > a {
-    padding-top:    3px;
-    padding-bottom: 3px;
-    padding-left: 30px;
-    font-size: 90%;
+    font-weight: normal;
 }
 
 .headerlink {


### PR DESCRIPTION
This just applies the CSS patch from mkdocs/mkdocs#1970 to each of the Bootswatch themes. I tested it out briefly and it all seems to work, including using `navigation_depth` to adjust the depth of the TOC.